### PR TITLE
NEXUS task 58

### DIFF
--- a/upload_viollier_raw
+++ b/upload_viollier_raw
@@ -85,8 +85,7 @@ while read aufxx ethid rest; do
 			fi
 			continue
 		elif [[ ${ethid} == *$'\n'* ]]; then
-			echo "(problem with ${aufnum}: multiple matches: ${ethid//$'\n'/ })"
-			continue
+			echo "(${aufnum}: multiple matches: ${ethid//$'\n'/ }\nUploading all matches)"
 		fi
 	elif [[ ! ${ethid} =~ ^[[:digit:]]{6,} ]]; then
 		echo "cannot parse ${ethid}" >&2
@@ -94,9 +93,13 @@ while read aufxx ethid rest; do
 		continue
 	fi
 
-	echo "${ethid} -> ${aufnum}"
-	[[ -d ${download}/${target}/${aufnum}/ ]] && rm -rf ${download}/${target}/${aufnum}/
-	cp --link -${verbose}rf ${sampleset}/${ethid}/ ${download}/${target}/${aufnum} || error=1
+	#new loop
+	for singleethid in ${ethid}
+	do
+		echo "${singleethid} -> ${aufnum}"
+		[[ -d ${download}/${target}/${aufnum}/ ]] && rm -rf ${download}/${target}/${aufnum}/
+		cp --link -${verbose}rf ${sampleset}/${singleethid}/ ${download}/${target}/${aufnum} || error=1
+	done
 done < <( cat ${1}; echo; )
 
 (( error )) && exit 0

--- a/upload_viollier_raw
+++ b/upload_viollier_raw
@@ -93,11 +93,11 @@ while read aufxx ethid rest; do
 		continue
 	fi
 
+	[[ -d ${download}/${target}/${aufnum}/ ]] && rm -rf ${download}/${target}/${aufnum}/
 	#new loop
 	for singleethid in ${ethid}
 	do
 		echo "${singleethid} -> ${aufnum}"
-		[[ -d ${download}/${target}/${aufnum}/ ]] && rm -rf ${download}/${target}/${aufnum}/
 		cp --link -${verbose}rf ${sampleset}/${singleethid}/ ${download}/${target}/${aufnum} || error=1
 	done
 done < <( cat ${1}; echo; )


### PR DESCRIPTION
Trivial solution applied to solve [issue 58](https://gitlab.ethz.ch/sars_cov_2/s3c-it-tasks/-/issues/58).
Changes happen only in upload_viollier_raw.

Whenever searching an `aufnum` in the `sampleset` files leads to multiple matches, the following happens:

- The script logs the matches but does not skip the entry anymore
- A loop is added that links (and reports in `request_results.txt`) all matching folders
- The removal of old folders is kept outside of the loop, so that the main `aufnum` folder can be populated by the multiple entries without being removed at every iteration

More specifically, the folder for the `aufnum` is created and, in there, all matching batch subfolder are copied, one after the other.
This solution keeps the main folder structure with `aufnum` intact. For multiple matches, instead of the corresponding folder having only 1 subfolder named after the single batch the sample comes from, multiple subfolders, one per match, are added.
This also ensures that Viollier has a reference as to what sequencing run the sample came from.

Possible pitfalls: In case we have multiple samples with exactly the same sample name in a single batch, this would make the link fail and would trigger the error. This is not expected to happen