### PR TITLE
added automation for viloca

### DIFF
--- a/batman.sh
+++ b/batman.sh
@@ -241,7 +241,31 @@ case "$1" in
 	;;
 	viloca)
 		# start first job
-		cd ${clusterdir}/${vilocadir}/
 		./run_workflow.sh
+		list=('viloca')
+		while [[ -n $2 ]]; do
+			case "$2" in
+				--tag)
+					shift
+					if [[ ! "${2}" =~ ^[[:alnum:]]+$ ]]; then
+						# if it's not just letters and number, test if it is a list of valid batches
+						validateTags ';' "$2"
+					fi
+					tag="${2%;}"
+				;;
+				*)
+					echo "Unkown parameter ${2}" > /dev/stderr
+					exit 2
+				;;
+			esac
+			shift
+		done
+		# start first job
+		cd ${clusterdir}/${vilocadir}/
+		. run_workflow.sh
+		# write job chain list
+		for v in "${list[@]}"; do
+			printf "%s\t%s\n" "${v}" "${job[$v]}"
+		done
 	;;
 esac

--- a/batman.sh
+++ b/batman.sh
@@ -268,4 +268,9 @@ case "$1" in
 			printf "%s\t%s\n" "${v}" "${job[$v]}"
 		done
 	;;
+	unlock_viloca)
+		cd ${clusterdir}/${vilocadir}/
+		. ../../miniconda3/bin/activate 'base'
+		snakemake --unlock
+	;;
 esac

--- a/batman.sh
+++ b/batman.sh
@@ -3,6 +3,7 @@
 clusterdir=/cluster/project/pangolin
 working=working
 sampleset=sampleset
+vilocadir=work-viloca/SARS-CoV-2-wastewater-sample-processing-VILOCA
 
 #
 # Input validator
@@ -237,5 +238,10 @@ case "$1" in
 	*)
 		echo "Unkown sub-command ${1}" > /dev/stderr
 		exit 2
+	;;
+	viloca)
+		# start first job
+		cd ${clusterdir}/${vilocadir}/
+		./run_workflow.sh
 	;;
 esac

--- a/belfry
+++ b/belfry
@@ -99,6 +99,20 @@ callpushrsync() {
 }
 export -f callpushrsync
 
+callpushsamplelist_viloca() {
+	. server.conf
+
+	exec	timeout ${timeoutforeground} --signal=INT --kill-after=5 $((rsynctimeout+contimeout+5))	\
+		rsync	--timeout=${iotimeout}	\
+		--password-file ~/rsync.pass.euler	\
+		-e "ssh -i ${HOME}/.ssh/id_ed25519_belfry -l ${cluster_user}  -oConnectTimeout=${contimeout}"	\
+		-izrltH --fuzzy --fuzzy --inplace	\
+		-p --chmod=Dg+s,ug+rw,o-rwx,Fa-x	\
+		-g --chown=:'bsse-covid19-pangolin-euler'	\
+		"${viloca_samples}"	\
+		belfry@euler.ethz.ch::${viloca_remote_basedir}/
+}
+export -f callpushsamplelist_viloca
 
 callpullrsync() {
 	. server.conf
@@ -441,6 +455,7 @@ case "$1" in
 			-g --chown=:'bsse-covid19-pangolin-euler'	\
 			${viloca_basedir}/samples.csv	\
 			belfry@euler.ethz.ch::${viloca_remote_basedir}/ || (( ++err ))
+		bash -c "callpushsamplelist_viloca " || (( ++err ))
 		if (( err )); then
 			echo "Error: ${err} rsync job(s) failed"
 			touch ${statusdir}/pushsamplelist_viloca_fail

--- a/belfry
+++ b/belfry
@@ -18,6 +18,9 @@ declare -A lab
 : ${retries:=10}
 : ${iotimeout:=300}
 : ${protocolyaml:=/references/primers.yaml}
+: ${viloca_results:?}
+: ${viloca_remote_basedir:work-viloca}
+: ${viloca_remote_resultsdir:results}
 
 if [[ $(realpath $scriptdir) != $(realpath $basedir) ]]; then
 	echo "$scriptdir vs $basedir"
@@ -36,6 +39,8 @@ umask 0002
 
 statusdir="${basedir}/status"
 mkdir ${mode:+--mode=${mode}} -p ${statusdir}
+viloca_statusdir="${basedir}/${viloca_basedir}/status"
+mkdir ${mode:+--mode=${mode}} -p ${viloca_statusdir}
 
 baseconda=$HOME/
 timeoutforeground=
@@ -159,6 +164,28 @@ callpullrsync_noshorah() {
 }
 export -f callpullrsync_noshorah
 
+callpullrsync_viloca() {
+	. server.conf
+
+	local arglist=( )
+	if (( ${#@} )); then
+		arglist=( "${@/#/belfry@euler.ethz.ch::${working}/samples/}" )
+	else
+		#arglist=( "belfry@euler.ethz.ch::${working}/samples/" )
+		echo "rsync job didn't receive list"
+		exit 1;
+	fi
+	exec	timeout ${timeoutforeground} --signal=INT --kill-after=5 $((rsynctimeout+contimeout+5))	\
+		rsync	--timeout=${iotimeout}	\
+		--password-file ~/rsync.pass.euler	\
+		-e "ssh -i ${HOME}/.ssh/id_ed25519_belfry -l ${cluster_user}  -oConnectTimeout=${contimeout}"	\
+		-izrltH --fuzzy --fuzzy --inplace	\
+		--link-dest=${viloca_remote_basedir}/${viloca_remote_results}/	\
+		"${arglist[@]}"	\
+		--exclude='alignment/'	\
+		${viloca_results}/
+}
+export -f callpullrsync_viloca
 
 #
 # sync helper
@@ -403,6 +430,24 @@ case "$1" in
 			touch ${statusdir}/pushsampleset_success
 		fi
 	;;
+	pushvilocasamplelist)
+		err=0
+		timeout ${timeoutforeground} --signal=INT --kill-after=5 $((rsynctimeout+contimeout+5))	\
+			rsync	--timeout=${iotimeout}	\
+			--password-file ~/rsync.pass.euler	\
+			-e "ssh -i ${HOME}/.ssh/id_ed25519_belfry -l ${cluster_user}  -oConnectTimeout=${contimeout}"	\
+			-izrltH --fuzzy --fuzzy --inplace	\
+			-p --chmod=Dg+s,ug+rw,o-rwx,Fa-x	\
+			-g --chown=:'bsse-covid19-pangolin-euler'	\
+			${viloca_basedir}/samples.csv	\
+			belfry@euler.ethz.ch::${viloca_remote_basedir}/ || (( ++err ))
+		if (( err )); then
+			echo "Error: ${err} rsync job(s) failed"
+			touch ${statusdir}/pushsamplelist_viloca_fail
+		else
+			touch ${statusdir}/pushsamplelist_viloca_success
+		fi
+	;;
 	listsamples)
 		timeout ${timeoutforeground} --signal=INT --kill-after=5 $((rsynctimeout+contimeout+5))	\
 			rsync	--timeout=${iotimeout}	\
@@ -573,6 +618,48 @@ case "$1" in
 			rmdir "${f%/}"
 		done
 		mv "${sampleset}/batch.${2}.yaml" "${sampleset}/samples.${2}.tsv" "${sampleset}/missing.${2}.txt" "${sampleset}/projects.${2}.tsv" garbage/
+	;;
+	pullsamples_viloca)
+		# fetch remote sheets
+		mkdir -p /tmp/belfrysheets/
+		if [[ "${2}" = "--batch" ]]; then
+			validateBatchName "${3}"
+			sheets=( "belfry@euler.ethz.ch::${sampleset}/samples.${3}.tsv"  )
+		elif [[ "${2}" = "--catchup" ]]; then
+			sheets=( "belfry@euler.ethz.ch::catchup/samples.catchup.tsv"  )
+		else
+			sheets=( "belfry@euler.ethz.ch::${sampleset}/samples.2*.tsv" )
+		fi
+		rsync	\
+			--password-file ~/rsync.pass.euler	\
+			-e "ssh -i ${HOME}/.ssh/id_ed25519_belfry -l ${cluster_user} "	\
+			-izrltH --fuzzy --fuzzy --inplace	\
+			-p --chmod=Dg+s,ug+rw,o-rwx	\
+			-g --chown=:"${storgrp}"	\
+			"${sheets[@]}"	\
+			/tmp/belfrysheets/
+		if [[ "${2}" = "--batch" ]]; then
+			validateBatchName "${3}"
+			sheets=( "/tmp/belfrysheets/samples.${3}.tsv"  )
+		elif [[ "${2}" = "--catchup" ]]; then
+			sheets=( "/tmp/belfrysheets/samples.catchup.tsv"  )
+		else
+			sheets=( /tmp/belfrysheets/samples.2*.tsv )
+		fi
+		err=0
+		echo "samples:"
+		cut -s --fields=1 "${sheets[@]}"|sort -u|	\
+			gawk -v P=$(( parallelpull * 4 )) '{i=(NR-1);b=i%P;o[b]=(o[b] " \"" $1 "\"")};END{for(i=0;i<P;i++){printf("%s\0",o[i])}}'|	\
+			xargs -0 -P $parallelpull -I '{@LIST@}' --	\
+				bash -c "callpullrsync_viloca {@LIST@} " || (( ++err ))
+		if (( err )); then
+			echo "Error: ${err} rsync job(s) failed"
+			touch ${viloca_statusdir}/pullsamples_viloca_fail
+		elif [[ "${2}" = "--catchup" ]]; then
+			echo -e '\n\e[38;5;45;1mFor the good of all of us\e[0m\n\e[38;5;208;1mExcept the ones who are dead\e[0m'
+		else
+			touch ${viloca_statusdir}/pullsamples_viloca_success
+		fi
 	;;
 	*)
 		echo "Unkown sub-command ${1}" > /dev/stderr

--- a/carillon
+++ b/carillon
@@ -24,7 +24,7 @@ umask 0002
 
 statusdir="${basedir}/status"
 mkdir ${mode:+--mode=${mode}} -p ${statusdir}
-viloca_statusdir="${basedir}/${viloca_basedir}/status"
+viloca_statusdir="${viloca_basedir}/status"
 mkdir ${mode:+--mode=${mode}} -p ${viloca_statusdir}
 viloca_staging=${viloca_samples}.staging
 lockfile=${statusdir}/carillon_lock
@@ -484,10 +484,6 @@ if run_viloca; then
 	echo "===================="
 	mustrun_viloca=0
 	if [[ ( ( ! -e ${viloca_statusdir}/viloca_ended ) && ( ! -e ${viloca_statusdir}/viloca_started ) ) || ( ${viloca_statusdir}/viloca_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
-		#### TODO: HERE ADD THE LIMITATION TO RUN ONLY ON THE VERY LATEST BATCH AND RE-ADD BACK RUNREASON	
-		ref=$(date --reference="${viloca_statusdir}/viloca_started" '+%Y%m%d')
-		now=$(date '+%Y%m%d')
-		limit=$(date --date='2 weeks ago' '+%Y%m%d')
 		if [[ ! -f ${viloca_samples} ]]; then
 			echo "Can't find ${viloca_samples}, creating it empty"
 			echo ",sample,batch" > ${viloca_samples}
@@ -495,24 +491,21 @@ if run_viloca; then
 		if [[ ! -f ${viloca_staging} ]]; then
 			echo "No staging file availabe, creating it"
 			cat ${viloca_samples} > ${viloca_staging}
-
-		else
-
-		### TODO: HERE, just trust vpipe
-		lastbatch_viloca = $(cat $(ls -Art ${viloca_statusdir}/viloca_new* | tail -n 1))
+		fi
+		lastbatch_viloca=$(cat $(ls -Art ${viloca_statusdir}/viloca_new* | tail -n 1))
 		echo "Last batch analysed by VILOCA is ${lastbatch_viloca}"
-		vpipe_enddate = $(cat ${statusdir}/vpipe_ended)
-		vpipe_enddate = ${vpipe_enddate#*.}
-		lastbatch_vpipe = $(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}')
+		vpipe_enddate=$(cat ${statusdir}/vpipe_ended)
+		vpipe_enddate=${vpipe_enddate#*.}
+		lastbatch_vpipe=$(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}')
 		echo "The most recent completed V-Pipe run is on batch ${lastbatch_vpipe}"
 		if [[ lastbatch_viloca != lastbatch_vpipe ]]; then
 			echo "There is a new most recent batch that VILOCA can run on!"
-			t = ${basedir}/${sampleset}/samples.${lastbatch_vpipe}.tsv
+			t=${basedir}/${sampleset}/samples.${lastbatch_vpipe}.tsv
 			if [[ ! $t =~ samples.([[:digit:]]{8})_([[:alnum:]]{5,}(-[[:digit:]]+)?).tsv$ ]]; then
 							echo "oops: Can't parse <${t}> ?!" > /dev/stderr
 			fi
+			echo ",sample,batch" > $viloca_staging
 			cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
-			cat $viloca_staging | sort | uniq > $viloca_staging
 			++mustrun_viloca
 
 		else
@@ -536,20 +529,26 @@ if run_viloca; then
 			else
 				echo 'starting VILOCA jobs'
 				mv ${viloca_staging} ${viloca_samples}
-				${remote_batman} viloca --recent --tag "${lastbatch_vpipe}" > ${viloca_statusdir}/viloca.${now}	&&	\
-				if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
-					ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
-					cat ${viloca_statusdir}/viloca_started
-					printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
-					if [[ -n "${mailto[*]}" ]]; then
-						(
-							echo '(Possibly new) samples not having VILOCA results yet found:'
-							printf ' - %s\n' "${lastbatch_vpipe}"
-							echo -e '\nStarting VILOCA on Euler:'
-							cat ${viloca_statusdir}/viloca_started
-						) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
-						# -r "${mailfrom}"
+				${scriptdir}/belfry pushvilocasamplelist
+				if [[ ( ! -e ${viloca_statusdir}/pushsamplelist_viloca_fail ) || ( ${viloca_statusdir}/pushsamplelist_viloca_success -nt ${viloca_statusdir}/pushsamplelist_viloca_fail ) ]]; then
+					echo Successfully pushed sample list for VILOCA. Starting the run
+					${remote_batman} viloca --recent --tag "${lastbatch_vpipe}" > ${viloca_statusdir}/viloca.${now}	&&	\
+					if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
+						ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
+						cat ${viloca_statusdir}/viloca_started
+						printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
+						if [[ -n "${mailto[*]}" ]]; then
+							(
+								echo '(Possibly new) samples not having VILOCA results yet found:'
+								printf ' - %s\n' "${lastbatch_vpipe}"
+								echo -e '\nStarting VILOCA on Euler:'
+								cat ${viloca_statusdir}/viloca_started
+							) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
+							# -r "${mailfrom}"
+						fi
 					fi
+				else
+					echo "pushing VILOCA sample list failed"
 				fi
 			fi
 		else

--- a/carillon
+++ b/carillon
@@ -442,6 +442,7 @@ if run_viloca; then
 			echo "No VILOCA running. Checking if the run was successful or if it ended prematurely due to the time limit"
 			if grep -rq snake.err -e "JOB.*CANCELLED.*DUE TO TIME LIMIT"; then
 				echo "Previous VILOCA run cancelled due to time limit. Restarting it"
+				${remote_batman} unlock_viloca && \
 				${remote_batman} viloca --recent --tag "${lastbatch_vpipe}" > ${viloca_statusdir}/viloca.${now}	&&	\
 				if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
 					ln -sf viloca.${now} ${viloca_statusdir}/viloca_started

--- a/carillon
+++ b/carillon
@@ -496,7 +496,7 @@ if run_viloca; then
 		echo "Last batch analysed by VILOCA is ${lastbatch_viloca}"
 		vpipe_enddate=$(cat ${statusdir}/vpipe_ended)
 		vpipe_enddate=${vpipe_enddate#*.}
-		lastbatch_vpipe=$(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}')
+		lastbatch_vpipe=$(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}' | tail -n 1)
 		echo "The most recent completed V-Pipe run is on batch ${lastbatch_vpipe}"
 		if [[ lastbatch_viloca != lastbatch_vpipe ]]; then
 			echo "There is a new most recent batch that VILOCA can run on!"
@@ -506,7 +506,7 @@ if run_viloca; then
 			fi
 			echo ",sample,batch" > $viloca_staging
 			cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
-			++mustrun_viloca
+			(( ++mustrun_viloca ))
 
 		else
 			echo "No new batch to run VILOCA on"

--- a/carillon
+++ b/carillon
@@ -442,7 +442,7 @@ if run_viloca; then
 			echo "No VILOCA running. Checking if the run was successful or if it ended prematurely due to the time limit"
 			if grep -rq snake.err -e "JOB.*CANCELLED.*DUE TO TIME LIMIT"; then
 				echo "Previous VILOCA run cancelled due to time limit. Restarting it"
-				${remote_batman} viloca --recent --tag "$(join_by ';' "${runreason[@]}")" > ${viloca_statusdir}/viloca.${now}	&&	\
+				${remote_batman} viloca --recent --tag "${lastbatch_vpipe}" > ${viloca_statusdir}/viloca.${now}	&&	\
 				if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
 					ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
 					cat ${viloca_statusdir}/viloca_started

--- a/carillon
+++ b/carillon
@@ -24,6 +24,9 @@ umask 0002
 
 statusdir="${basedir}/status"
 mkdir ${mode:+--mode=${mode}} -p ${statusdir}
+viloca_statusdir="${basedir}/${viloca_basedir}/status"
+mkdir ${mode:+--mode=${mode}} -p ${viloca_statusdir}
+viloca_staging=${viloca_samples}.staging
 lockfile=${statusdir}/carillon_lock
 
 remote_batman="ssh -ni ${HOME}/.ssh/id_ed25519_batman -l ${cluster_user} euler.ethz.ch --"
@@ -214,7 +217,6 @@ echo "============="
 
 # TODO support a yaml with regex
 rxsample='(^[[:digit:]]{6,}_)|(^[[:digit:]]{8,})|(^Y[[:digit:]]{8,})|([[:digit:]]{2}_20[[:digit:]]{2}_[01]?[[:digit:]]_[0-3]?[[:digit:]])|(^KLZHC[oO][vV])|(^B[aA][[:digit:]]{4,})|(^USB_20[[:digit:]]{2}_[01]?[[:digit:]]_[[:digit:]]{2}_.{8})'
-#rxsample='^[[:digit:]]{6,}_'
 
 scanmissingsamples() {
 	while read sample batch other; do 
@@ -382,6 +384,166 @@ if [[ ( ( ! -e ${statusdir}/vpipe_ended ) && ( ! -e ${statusdir}/vpipe_started )
 	fi
 else
 	echo 'There is already run going on'
+fi
+
+#
+# Phase 5: run viloca on new samples if no viloca instance is running
+#
+
+echo "========================"
+echo "Check current VILOCA run"
+echo "========================"
+
+
+if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
+	stillrunning=0
+	while read j id; do
+		# skip missing
+		if [[ -z "${id}" ]]; then
+			echo "VILOCA - $j : (not started)"
+			continue
+		fi
+
+		# skip already finished
+		if [[ ( -e ${viloca_statusdir}/viloca_${j}_ended ) && ( ${viloca_statusdir}/viloca_${j}_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
+			old="$(<${viloca_statusdir}/viloca_${j}_ended)"
+			if [[ "${id}" == "${old}" ]]; then
+				echo "VILOCA - $j : $id already finished"
+			else
+				echo "VILOCA - $j : mismatch $id vs $old"
+			fi
+			continue
+		fi
+
+		# cluster status
+		stat=$(${remote_batman} job "${id}" || echo "(no answer)")
+		if [[ ( -n "${stat}" ) && ( ! "${stat}" =~ (EXIT|DONE) ) ]]; then
+			# running
+			echo -n "VILOCA - $j : $id : $stat"
+			(( ++stillrunning ))
+			if [[ "${stat}" == 'RUN' && ( ! "$j" =~ qa$ ) ]]; then
+				echo -ne '\t'
+				${remote_batman} completion "${id}" | tail -n 1
+			else
+				echo ''
+			fi
+			sleep 1
+			continue
+		fi
+
+		# not running
+		echo "VILOCA - $j : $id finishing"
+
+		echo "${id}" > ${viloca_statusdir}/viloca_${j}_ended
+	done < ${viloca_statusdir}/viloca_started
+
+	if (( stillrunning == 0 )); then
+		${scriptdir}/belfry pullsamples_viloca --recent
+		if [[ ( ! -e ${viloca_statusdir}/pullsamples_viloca_fail ) || ( ${viloca_statusdir}/pullsamples_viloca_success -nt ${viloca_statusdir}/pullsamples_viloca_fail ) ]]; then
+			echo "$(basename $(realpath ${viloca_statusdir}/viloca_started))" > ${viloca_statusdir}/viloca_ended
+		else
+			echo "pulling VILOCA data failed"
+		fi
+	fi
+else
+	echo 'No current VILOCA run.'
+fi
+
+#
+# Phase 6: restart VILOCA runs if new data
+#
+
+echo "===================="
+echo "Start new VILOCA run"
+echo "===================="
+
+if [[ ( ( ! -e ${viloca_statusdir}/viloca_ended ) && ( ! -e ${viloca_statusdir}/viloca_started ) ) || ( ${viloca_statusdir}/viloca_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
+	mustrun_viloca=0
+	ref=$(date --reference="${viloca_statusdir}/viloca_started" '+%Y%m%d')
+	now=$(date '+%Y%m%d')
+	limit=$(date --date='2 weeks ago' '+%Y%m%d')
+	if [[ ! -f ${viloca_samples} ]]; then
+		echo "Can't find ${viloca_samples}, creating it empty"
+		echo ",sample,batch" > ${viloca_samples}
+	fi
+	if [[ ! -f ${viloca_staging} ]]; then
+		echo "No staging file availabe, creating it"
+		cat ${viloca_samples} > ${viloca_staging}
+
+	else
+
+	echo "Check batch against ${ref}:"
+	for t in ${basedir}/${sampleset}/samples.*.tsv; do
+		if [[ ! $t =~ samples.([[:digit:]]{8})_([[:alnum:]]{5,}(-[[:digit:]]+)?).tsv$ ]]; then
+			echo "oops: Can't parse <${t}> ?!" > /dev/stderr
+		fi
+
+		batchname=${${t#*.}%".tsv"}
+		analysed_batches=$(cat $viloca_staging | awk -F ',' '{print $3}' | sort | uniq)
+		# check if any sample from the batch has been added already
+		if [[ ${analysed_batches[*]} =~ $batchname ]]; then
+		    #If yes, check if all of them have been added or if new ones appeared in the meantime
+			if [ $(wc -l < $t) -eq $(grep -o $batchname <<< ${analysed_batches} | wc -l) ]; then
+				continue
+			else
+				echo "Found new samples for batch $batchname"
+				# check if this batch is still being processed by Vpipe
+				batch_status_file=grep -rl ${statusdir}/vpipe_new.* -e $batchname
+				batch_run_date=${batch_status_file#*.}
+				if [ ( ${batch_status_file#*.} -lt ${$(cat ${statusdir}/vpipe_ended)#*.} ) || ( ${batch_status_file#*.} -eq ${$(cat ${statusdir}/vpipe_ended)#*.} ) ]; then
+					echo "that Vpipe finished analysing. Updating the VILOCA staging samples list"
+					cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
+					cat $viloca_staging | sort | uniq > $viloca_staging
+					++mustrun_viloca					
+				else
+					echo "that Vpipe is STILL analysing. Ignoring until next loop"
+					continue
+				fi
+			fi
+		else
+			echo "Found new completed batch: $batchname. Updating the VILOCA staging samples list"
+			cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
+			++mustrun_viloca
+		fi
+
+	# are we allowed to submit jobs ?
+	if (( donotsubmit_viloca )); then
+		echo -e '\e[35;1mWill NOT submit VILOCA jobs\e[0m...' > /dev/stderr
+		if (( mustrun_viloca )); then
+			echo 'VILOCA submit blocked' > ${viloca_statusdir}/viloca_submit_fail
+			echo -e '...\e[33;1mbut there are new VILOCA jobs that should be started !!!\e[0m' > /dev/stderr
+		else
+			echo '...and there is nothing VILOCA-related to run anyway' > /dev/stderr
+		fi
+	# start jobs ?
+	elif (( mustrun_viloca )); then
+		echo 'New VILOCA job waiting. Checking if Viloca is already running...'
+		if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
+			echo "BUT there is already a VILOCA instance running! Retrying during the next loop"
+		else
+			echo 'starting VILOCA jobs'
+			mv ${viloca_staging} ${viloca_samples}
+			${remote_batman} viloca --recent --tag "$(join_by ';' "${runreason[@]}")" > ${viloca_statusdir}/viloca.${now}	&&	\
+			if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
+				ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
+				cat ${viloca_statusdir}/viloca_started
+				printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
+				if [[ -n "${mailto[*]}" ]]; then
+					(
+						echo '(Possibly new) samples not having VILOCA results yet found:'
+						printf ' - %s\n' "${runreason[@]}"
+						echo -e '\nStarting VILOCA on Euler:'
+						cat ${viloca_statusdir}/viloca_started
+					) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
+					# -r "${mailfrom}"
+				fi
+			fi
+		fi
+	else
+		echo 'No new VILOCA jobs to start'
+	fi
+else
+	echo 'There is already A VILOCA run going on'
 fi
 
 #

--- a/carillon
+++ b/carillon
@@ -389,163 +389,177 @@ fi
 #
 # Phase 5: run viloca on new samples if no viloca instance is running
 #
+if run_viloca; then
 
-echo "========================"
-echo "Check current VILOCA run"
-echo "========================"
+	echo "========================"
+	echo "Check current VILOCA run"
+	echo "========================"
 
 
-if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
-	stillrunning=0
-	while read j id; do
-		# skip missing
-		if [[ -z "${id}" ]]; then
-			echo "VILOCA - $j : (not started)"
-			continue
-		fi
-
-		# skip already finished
-		if [[ ( -e ${viloca_statusdir}/viloca_${j}_ended ) && ( ${viloca_statusdir}/viloca_${j}_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
-			old="$(<${viloca_statusdir}/viloca_${j}_ended)"
-			if [[ "${id}" == "${old}" ]]; then
-				echo "VILOCA - $j : $id already finished"
-			else
-				echo "VILOCA - $j : mismatch $id vs $old"
-			fi
-			continue
-		fi
-
-		# cluster status
-		stat=$(${remote_batman} job "${id}" || echo "(no answer)")
-		if [[ ( -n "${stat}" ) && ( ! "${stat}" =~ (EXIT|DONE) ) ]]; then
-			# running
-			echo -n "VILOCA - $j : $id : $stat"
-			(( ++stillrunning ))
-			if [[ "${stat}" == 'RUN' && ( ! "$j" =~ qa$ ) ]]; then
-				echo -ne '\t'
-				${remote_batman} completion "${id}" | tail -n 1
-			else
-				echo ''
-			fi
-			sleep 1
-			continue
-		fi
-
-		# not running
-		echo "VILOCA - $j : $id finishing"
-
-		echo "${id}" > ${viloca_statusdir}/viloca_${j}_ended
-	done < ${viloca_statusdir}/viloca_started
-
-	if (( stillrunning == 0 )); then
-		${scriptdir}/belfry pullsamples_viloca --recent
-		if [[ ( ! -e ${viloca_statusdir}/pullsamples_viloca_fail ) || ( ${viloca_statusdir}/pullsamples_viloca_success -nt ${viloca_statusdir}/pullsamples_viloca_fail ) ]]; then
-			echo "$(basename $(realpath ${viloca_statusdir}/viloca_started))" > ${viloca_statusdir}/viloca_ended
-		else
-			echo "pulling VILOCA data failed"
-		fi
-	fi
-else
-	echo 'No current VILOCA run.'
-fi
-
-#
-# Phase 6: restart VILOCA runs if new data
-#
-
-echo "===================="
-echo "Start new VILOCA run"
-echo "===================="
-
-if [[ ( ( ! -e ${viloca_statusdir}/viloca_ended ) && ( ! -e ${viloca_statusdir}/viloca_started ) ) || ( ${viloca_statusdir}/viloca_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
-	mustrun_viloca=0
-	ref=$(date --reference="${viloca_statusdir}/viloca_started" '+%Y%m%d')
-	now=$(date '+%Y%m%d')
-	limit=$(date --date='2 weeks ago' '+%Y%m%d')
-	if [[ ! -f ${viloca_samples} ]]; then
-		echo "Can't find ${viloca_samples}, creating it empty"
-		echo ",sample,batch" > ${viloca_samples}
-	fi
-	if [[ ! -f ${viloca_staging} ]]; then
-		echo "No staging file availabe, creating it"
-		cat ${viloca_samples} > ${viloca_staging}
-
-	else
-
-	echo "Check batch against ${ref}:"
-	for t in ${basedir}/${sampleset}/samples.*.tsv; do
-		if [[ ! $t =~ samples.([[:digit:]]{8})_([[:alnum:]]{5,}(-[[:digit:]]+)?).tsv$ ]]; then
-			echo "oops: Can't parse <${t}> ?!" > /dev/stderr
-		fi
-
-		batchname=${${t#*.}%".tsv"}
-		analysed_batches=$(cat $viloca_staging | awk -F ',' '{print $3}' | sort | uniq)
-		# check if any sample from the batch has been added already
-		if [[ ${analysed_batches[*]} =~ $batchname ]]; then
-		    #If yes, check if all of them have been added or if new ones appeared in the meantime
-			if [ $(wc -l < $t) -eq $(grep -o $batchname <<< ${analysed_batches} | wc -l) ]; then
+	if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
+		stillrunning=0
+		while read j id; do
+			# skip missing
+			if [[ -z "${id}" ]]; then
+				echo "VILOCA - $j : (not started)"
 				continue
-			else
-				echo "Found new samples for batch $batchname"
-				# check if this batch is still being processed by Vpipe
-				batch_status_file=grep -rl ${statusdir}/vpipe_new.* -e $batchname
-				batch_run_date=${batch_status_file#*.}
-				if [ ( ${batch_status_file#*.} -lt ${$(cat ${statusdir}/vpipe_ended)#*.} ) || ( ${batch_status_file#*.} -eq ${$(cat ${statusdir}/vpipe_ended)#*.} ) ]; then
-					echo "that Vpipe finished analysing. Updating the VILOCA staging samples list"
-					cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
-					cat $viloca_staging | sort | uniq > $viloca_staging
-					++mustrun_viloca					
-				else
-					echo "that Vpipe is STILL analysing. Ignoring until next loop"
-					continue
-				fi
 			fi
-		else
-			echo "Found new completed batch: $batchname. Updating the VILOCA staging samples list"
-			cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
-			++mustrun_viloca
-		fi
 
-	# are we allowed to submit jobs ?
-	if (( donotsubmit_viloca )); then
-		echo -e '\e[35;1mWill NOT submit VILOCA jobs\e[0m...' > /dev/stderr
-		if (( mustrun_viloca )); then
-			echo 'VILOCA submit blocked' > ${viloca_statusdir}/viloca_submit_fail
-			echo -e '...\e[33;1mbut there are new VILOCA jobs that should be started !!!\e[0m' > /dev/stderr
-		else
-			echo '...and there is nothing VILOCA-related to run anyway' > /dev/stderr
-		fi
-	# start jobs ?
-	elif (( mustrun_viloca )); then
-		echo 'New VILOCA job waiting. Checking if Viloca is already running...'
-		if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
-			echo "BUT there is already a VILOCA instance running! Retrying during the next loop"
-		else
-			echo 'starting VILOCA jobs'
-			mv ${viloca_staging} ${viloca_samples}
-			${remote_batman} viloca --recent --tag "$(join_by ';' "${runreason[@]}")" > ${viloca_statusdir}/viloca.${now}	&&	\
-			if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
-				ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
-				cat ${viloca_statusdir}/viloca_started
-				printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
-				if [[ -n "${mailto[*]}" ]]; then
-					(
-						echo '(Possibly new) samples not having VILOCA results yet found:'
-						printf ' - %s\n' "${runreason[@]}"
-						echo -e '\nStarting VILOCA on Euler:'
-						cat ${viloca_statusdir}/viloca_started
-					) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
-					# -r "${mailfrom}"
+			# skip already finished
+			if [[ ( -e ${viloca_statusdir}/viloca_${j}_ended ) && ( ${viloca_statusdir}/viloca_${j}_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
+				old="$(<${viloca_statusdir}/viloca_${j}_ended)"
+				if [[ "${id}" == "${old}" ]]; then
+					echo "VILOCA - $j : $id already finished"
+				else
+					echo "VILOCA - $j : mismatch $id vs $old"
 				fi
+				continue
+			fi
+
+			# cluster status
+			stat=$(${remote_batman} job "${id}" || echo "(no answer)")
+			if [[ ( -n "${stat}" ) && ( ! "${stat}" =~ (EXIT|DONE) ) ]]; then
+				# running
+				echo -n "VILOCA - $j : $id : $stat"
+				(( ++stillrunning ))
+				if [[ "${stat}" == 'RUN' && ( ! "$j" =~ qa$ ) ]]; then
+					echo -ne '\t'
+					${remote_batman} completion "${id}" | tail -n 1
+				else
+					echo ''
+				fi
+				sleep 1
+				continue
+			fi
+
+			# not running
+			echo "VILOCA - $j : $id finishing"
+
+			echo "${id}" > ${viloca_statusdir}/viloca_${j}_ended
+		done < ${viloca_statusdir}/viloca_started
+
+		if (( stillrunning == 0 )); then
+			echo "No VILOCA running. Checking if the run was successful or if it ended prematurely due to the time limit"
+			if grep -rq snake.err -e "JOB.*CANCELLED.*DUE TO TIME LIMIT"; then
+				echo "Previous VILOCA run cancelled due to time limit. Restarting it"
+				${remote_batman} viloca --recent --tag "$(join_by ';' "${runreason[@]}")" > ${viloca_statusdir}/viloca.${now}	&&	\
+				if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
+					ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
+					cat ${viloca_statusdir}/viloca_started
+					printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
+					if [[ -n "${mailto[*]}" ]]; then
+						(
+							echo '(Possibly new) samples not having VILOCA results yet found:'
+							printf ' - %s\n' "${runreason[@]}"
+							echo -e '\nStarting VILOCA on Euler:'
+							cat ${viloca_statusdir}/viloca_started
+						) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
+						# -r "${mailfrom}"
+					fi
+				fi
+				continue
+			fi
+	    echo found
+	else
+	    echo not found
+	fi
+			${scriptdir}/belfry pullsamples_viloca --recent
+			if [[ ( ! -e ${viloca_statusdir}/pullsamples_viloca_fail ) || ( ${viloca_statusdir}/pullsamples_viloca_success -nt ${viloca_statusdir}/pullsamples_viloca_fail ) ]]; then
+				echo "$(basename $(realpath ${viloca_statusdir}/viloca_started))" > ${viloca_statusdir}/viloca_ended
+			else
+				echo "pulling VILOCA data failed"
 			fi
 		fi
 	else
-		echo 'No new VILOCA jobs to start'
+		echo 'No current VILOCA run.'
+	fi
+
+	#
+	# Phase 6: restart VILOCA runs if new data
+	#
+
+	echo "===================="
+	echo "Start new VILOCA run"
+	echo "===================="
+	mustrun_viloca=0
+	if [[ ( ( ! -e ${viloca_statusdir}/viloca_ended ) && ( ! -e ${viloca_statusdir}/viloca_started ) ) || ( ${viloca_statusdir}/viloca_ended -nt ${viloca_statusdir}/viloca_started ) ]]; then
+		#### TODO: HERE ADD THE LIMITATION TO RUN ONLY ON THE VERY LATEST BATCH AND RE-ADD BACK RUNREASON	
+		ref=$(date --reference="${viloca_statusdir}/viloca_started" '+%Y%m%d')
+		now=$(date '+%Y%m%d')
+		limit=$(date --date='2 weeks ago' '+%Y%m%d')
+		if [[ ! -f ${viloca_samples} ]]; then
+			echo "Can't find ${viloca_samples}, creating it empty"
+			echo ",sample,batch" > ${viloca_samples}
+		fi
+		if [[ ! -f ${viloca_staging} ]]; then
+			echo "No staging file availabe, creating it"
+			cat ${viloca_samples} > ${viloca_staging}
+
+		else
+
+		### TODO: HERE, just trust vpipe
+		lastbatch_viloca = $(cat $(ls -Art ${viloca_statusdir}/viloca_new* | tail -n 1))
+		echo "Last batch analysed by VILOCA is ${lastbatch_viloca}"
+		vpipe_enddate = $(cat ${statusdir}/vpipe_ended)
+		vpipe_enddate = ${vpipe_enddate#*.}
+		lastbatch_vpipe = $(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}')
+		echo "The most recent completed V-Pipe run is on batch ${lastbatch_vpipe}"
+		if [[ lastbatch_viloca != lastbatch_vpipe ]]; then
+			echo "There is a new most recent batch that VILOCA can run on!"
+			t = ${basedir}/${sampleset}/samples.${lastbatch_vpipe}.tsv
+			if [[ ! $t =~ samples.([[:digit:]]{8})_([[:alnum:]]{5,}(-[[:digit:]]+)?).tsv$ ]]; then
+							echo "oops: Can't parse <${t}> ?!" > /dev/stderr
+			fi
+			cat $t | awk '{print $1,$2}' | tr " " "," | sed 's/^/,/' >> $viloca_staging
+			cat $viloca_staging | sort | uniq > $viloca_staging
+			++mustrun_viloca
+
+		else
+			echo "No new batch to run VILOCA on"
+		fi
+	
+		# are we allowed to submit jobs ?
+		if (( donotsubmit_viloca )); then
+			echo -e '\e[35;1mWill NOT submit VILOCA jobs\e[0m...' > /dev/stderr
+			if (( mustrun_viloca )); then
+				echo 'VILOCA submit blocked' > ${viloca_statusdir}/viloca_submit_fail
+				echo -e '...\e[33;1mbut there are new VILOCA jobs that should be started !!!\e[0m' > /dev/stderr
+			else
+				echo '...and there is nothing VILOCA-related to run anyway' > /dev/stderr
+			fi
+		# start jobs ?
+		elif (( mustrun_viloca )); then
+			echo 'New VILOCA job waiting. Checking if Viloca is already running...'
+			if [[ ( -e ${viloca_statusdir}/viloca_started ) && ( ( ! -e ${viloca_statusdir}/viloca_ended ) || ( ${viloca_statusdir}/viloca_started -nt ${viloca_statusdir}/viloca_ended ) ) ]]; then
+				echo "BUT there is already a VILOCA instance running! Retrying during the next loop"
+			else
+				echo 'starting VILOCA jobs'
+				mv ${viloca_staging} ${viloca_samples}
+				${remote_batman} viloca --recent --tag "${lastbatch_vpipe}" > ${viloca_statusdir}/viloca.${now}	&&	\
+				if [[ -s ${viloca_statusdir}/viloca.${now} ]]; then
+					ln -sf viloca.${now} ${viloca_statusdir}/viloca_started
+					cat ${viloca_statusdir}/viloca_started
+					printf "%s\t$(date '+%H%M%S')\n" "${runreason[@]}" | tee -a ${viloca_statusdir}/viloca_new.${now}
+					if [[ -n "${mailto[*]}" ]]; then
+						(
+							echo '(Possibly new) samples not having VILOCA results yet found:'
+							printf ' - %s\n' "${lastbatch_vpipe}"
+							echo -e '\nStarting VILOCA on Euler:'
+							cat ${viloca_statusdir}/viloca_started
+						) | mail -s '[Automation-carillon] Starting VILOCA on Euler' "${mailto[@]}"
+						# -r "${mailfrom}"
+					fi
+				fi
+			fi
+		else
+			echo 'No new VILOCA jobs to start'
+		fi
+	else
+		echo 'There is already A VILOCA run going on'
 	fi
 else
-	echo 'There is already A VILOCA run going on'
+	echo "Skipping VILOCA as per configuration"
 fi
-
 #
 # Closing words
 #

--- a/server.conf
+++ b/server.conf
@@ -50,6 +50,7 @@ synctimeout=0
 cluster_user=bs-pangolin
 
 # VILOCA-specific configuration
+run_viloca=1
 donotsubmit_viloca=0
-viloca_basedir=/links/shared/covid19-pangolin/pangolin/work-viloca
-viloca_samples=/links/shared/covid19-pangolin/pangolin/work-viloca/config/samples.csv
+viloca_basedir=/links/shared/covid19-pangolin/backup/work-viloca
+viloca_samples=/links/shared/covid19-pangolin/backup/work-viloca/samples.csv

--- a/server.conf
+++ b/server.conf
@@ -54,3 +54,4 @@ run_viloca=1
 donotsubmit_viloca=0
 viloca_basedir=/links/shared/covid19-pangolin/backup/work-viloca
 viloca_samples=/links/shared/covid19-pangolin/backup/work-viloca/samples.csv
+viloca_results=/links/shared/covid19-pangolin/backup/work-viloca/results

--- a/server.conf
+++ b/server.conf
@@ -48,3 +48,8 @@ synctimeout=0
 
 # username used on the cluster (while we're switching over)
 cluster_user=bs-pangolin
+
+# VILOCA-specific configuration
+donotsubmit_viloca=0
+viloca_basedir=/links/shared/covid19-pangolin/pangolin/work-viloca
+viloca_samples=/links/shared/covid19-pangolin/pangolin/work-viloca/config/samples.csv


### PR DESCRIPTION
Added the main logic to run Viloca as part of the automation.
We should time deployment away from the usual processing times for WW to avoid undiscovered problems to affect regular submissions.

Changes:
- Taken large chunks of what the automation already did for Vpipe
- The automation monitors VILOCA exactly like it does for VPIPE
- At any given loop, the automation checks the "samples.*.tsv" files for a batch that is not part of the list of samples in input for VILOCA
  - if anything new is found (being it a whole new batch or new samples in a previously-added batch)
    - It checks if it's part of an already-finished vpipe run
      - if yes, it adds the new samples to the list of samples in input for VILOCA
- Introduced a "staging" list of samples in input for VILOCA which is the one that is updated by the loop, in order not to disrupt ongoing runs
- The VILOCA run is triggered only if no other VILOCA run is ongoing