### PR TITLE
added automation to queue raw uploads of new batches

### DIFF
--- a/batman.sh
+++ b/batman.sh
@@ -3,6 +3,8 @@
 clusterdir=/cluster/project/pangolin
 working=working
 sampleset=sampleset
+uploaddir=${clusterdir}/uploader/ww_raw
+uploadlist=to_upload_ww.tsv
 
 #
 # Input validator
@@ -233,6 +235,12 @@ case "$1" in
 			rmdir "${f%/}"
 		done
 		mv "${sampleset}/batch.${2}.yaml" "${sampleset}/samples.${2}.tsv" "${sampleset}/missing.${2}.txt" "${sampleset}/projects.${2}.tsv" garbage/
+	;;
+	queue_upload)
+		validateBatchName "$2"
+		cd ${uploaddir}
+		cat ${sampleset}/samples.${2}.tsv | awk '{print $1,$2}' | sed -e 's/ /\t/' >> ${uploadlist}
+		cat $uploadlist | sort | uniq > $uploadlist
 	;;
 	*)
 		echo "Unkown sub-command ${1}" > /dev/stderr

--- a/carillon
+++ b/carillon
@@ -169,6 +169,10 @@ if [[ ( -e ${statusdir}/vpipe_started ) && ( ( ! -e ${statusdir}/vpipe_ended ) |
 		${scriptdir}/belfry pullsamples_noshorah --recent
 		if [[ ( ! -e ${statusdir}/pullsamples_noshorah_fail ) || ( ${statusdir}/pullsamples_noshorah_success -nt ${statusdir}/pullsamples_noshorah_fail ) ]]; then
 			echo "$(basename $(realpath ${statusdir}/vpipe_started))" > ${statusdir}/vpipe_ended
+			vpipe_enddate = $(cat ${statusdir}/vpipe_ended)
+			vpipe_enddate = ${vpipe_enddate#*.}
+			lastbatch_vpipe = $(cat ${statusdir}/vpipe_new.${vpipe_enddate} | awk '{print $1}')
+			${remote_batman} queue_upload lastbatch_vpipe
 		else
 			echo "pulling data failed"
 		fi


### PR DESCRIPTION
Small changes to the automation to automatically add new wastewater samples to the list of samples to upload as soon as Vpipe completes the analysis of a batch.

structure:
- created a new `batman.sh` command that appends to the list of samples to upload all samples in the batch passed as argument
- added steps to `carillon`, right after `vpipe_ended` is generated, to retrieve the name of the completed batch and trigger the new `batman.sh` command.

Still a draft because we want this to go live once we have the full upload system ready