### PR TITLE
[FEAT] added exception to deal with samples without definition of the…

### DIFF
--- a/uploader/create_metadata_line.py
+++ b/uploader/create_metadata_line.py
@@ -10,6 +10,7 @@ import requests
 from datetime import datetime
 sys.path.append("/app/uploader")
 import submission_metadata as meta
+import rsv_exceptions as rsv_exc
 
 # parse command line
 def parse_args():
@@ -395,6 +396,9 @@ def main():
             if virus_shortname == ["rsv"]:
                 print("Found exception: rsv may include RSVA or RSVB for sequencing. Retrieving which")
                 for key, value in meta.rsv_kits.items():
+                    #If the sample is in the list of exceptions, change its kit name to what the exception list says, then move on with the check
+                    if mydata[0] in rsv_exc.rsv_exceptions.keys():
+                        mydata[3] = rsv_exc.rsv_exceptions[mydata[0]]
                     if mydata[3] in value:
                         virus_shortname = [key]
             # If the above code cannot find if we are talking about RSVA or RSVB, it means that virus_shortname stays "rsv". Below we test that to throw the error.

--- a/uploader/rsv_exceptions.py
+++ b/uploader/rsv_exceptions.py
@@ -1,0 +1,26 @@
+# When we track RSV, we may sequence subtype A, B, or both. That information is available as a dedicated column in the sequencing metadata and is used to fetch the dPCR values of the correct subtype from wisedb.
+# This file is an override in case of errors or missing values in the official metadata
+rsv_exceptions = {
+  "A1_05_2025_04_23": "RSV subtype A and B" 
+  "A2_16_2025_04_23": "RSV subtype A and B" 
+  "A3_25_2025_05_01": "RSV subtype A and B" 
+  "B1_05_2025_04_26": "RSV subtype A and B" 
+  "B2_16_2025_04_27": "RSV subtype A and B" 
+  "B3_25_2025_05_04": "RSV subtype A and B" 
+  "C1_10_2025_04_23": "RSV subtype A and B" 
+  "C2_05_2025_05_01": "RSV subtype A and B" 
+  "C3_15_2025_05_01": "RSV subtype A and B" 
+  "D1_10_2025_04_26": "RSV subtype A and B" 
+  "D2_05_2025_05_04": "RSV subtype A and B" 
+  "D3_15_2025_05_05": "RSV subtype A and B" 
+  "E1_17_2025_04_23": "RSV subtype A and B" 
+  "E2_10_2025_05_01": "RSV subtype A and B" 
+  "E3_16_2025_05_01": "RSV subtype A and B" 
+  "F1_17_2025_04_26": "RSV subtype A and B" 
+  "F2_10_2025_05_04": "RSV subtype A and B" 
+  "F3_16_2025_05_05": "RSV subtype A and B" 
+  "G1_25_2025_04_23": "RSV subtype A and B" 
+  "G2_17_2025_05_01": "RSV subtype A and B" 
+  "H1_25_2025_04_26": "RSV subtype A and B" 
+  "H2_17_2025_05_04": "RSV subtype A and B" 
+}


### PR DESCRIPTION
Added exceptions to the uploader routine. A new file is available to force on a sample a specific metadata string defining which RSV subtypes have been sequenced.
Such file is read during the generation of the SPSP upload metadata string for such sample and is supposed to either:
- define the metadata value for samples that have no such metadata field in the FGCZ delivery
- replace a wrong metadata value to the actual correct value 