### PR TITLE
[FEAT] added deletion of FGCZ raw data

### DIFF
--- a/cleanup_storage.sh
+++ b/cleanup_storage.sh
@@ -10,7 +10,7 @@ umask 0007
 shopt -s nullglob
 set +f
 
-custom_date=$(date '+%Y%m%d' --date='-3 months')
+custom_date=$(date '+%Y%m%d' --date='-6 months')
 
 if [ -z "${1-}" ]; then
   echo "Error: missing required argument." >&2
@@ -99,10 +99,9 @@ esac
 
 if [[ "$type" == "fgcz" ]];then
 	for prj in "${projlist[@]}"; do
-		custom_date=$(date -d "6 months ago" +%Y/%m/%d)
 		garbagedir="${clusterdir_old}/garbage/${type}/${prj}"
 		readarray -t dirs < <(
-			ls -l "${base}/${prj}" --time-style=+'%Y/%m/%d %H:%M:%S' | \
+			ls -l "${base}/${prj}" --time-style=+'%Y%m%d %H:%M:%S' | \
 				awk -v d="$custom_date" '$6 < d { print $8 }' | \
 				tail -n +2
 		)

--- a/cleanup_storage.sh
+++ b/cleanup_storage.sh
@@ -2,6 +2,7 @@
 
 scriptdir=/cluster/project/pangolin/test_automation/pangolin/pangolin_src
 . ${scriptdir}/config/server.conf
+. ${clusterdir}/config/fgcz.conf
 
 umask 0007
 
@@ -32,79 +33,123 @@ fi
 
 case "$1" in
 	clean_sampleset_covid)
-		virus="covid"
+		type="covid"
 		virusbase=(".")
 		parent="sampleset"
 		togarbage=("raw_data/*" "extracted_data/*")
 	;;
         clean_preproc_covid)
-		virus="covid"
+		type="covid"
 		virusbase=(".")
 		parent="working/samples"
 		togarbage=("preprocessed_data/*fastq.gz")
 	;;
 	clean_sampleset_rsv)
-		virus="rsv"
+		type="rsv"
 		virusbase=("rsv_pipeline")
 		parent="sampleset"
 		togarbage=("raw_data/*" "extracted_data/*")
 	;;
 	clean_preproc_rsv)
-		virus="rsv"
+		type="rsv"
 		virusbase=("rsv_pipeline/RSVA" "rsv_pipeline/RSVB")
 		parent="working/results"
 		togarbage=("preprocessed_data/*fastq.gz")
 	;;
 	clean_raw_rsv)
-		virus="rsv"
+		type="rsv"
                 virusbase=("rsv_pipeline/RSVA" "rsv_pipeline/RSVB")
                 parent="working/samples"
 		togarbage=("raw_data/*fastq.gz")
 	;;
 	clean_sampleset_flu)
-		virus="flu"
+		type="flu"
 		virusbase=("influenza_pipeline")
 		parent="sampleset"
 		togarbage=("raw_data/*" "extracted_data/*")
 	;;
 	clean_preproc_flu)
-		virus="flu"
+		type="flu"
 		virusbase=("influenza_pipeline/IA_H1" "influenza_pipeline/IA_H3" "influenza_pipeline/IA_MP" "influenza_pipeline/IA_N1" "influenza_pipeline/IA_N2")
 		parent="working/results"
 		togarbage=("preprocessed_data/*fastq.gz")
 	;;
 	clean_raw_flu)
-                virus="flu"
+                type="flu"
                 virusbase=("influenza_pipeline/IA_H1" "influenza_pipeline/IA_H3" "influenza_pipeline/IA_MP" "influenza_pipeline/IA_N1" "influenza_pipeline/IA_N2")
 		parent="working/samples"
                 togarbage=("raw_data/*fastq.gz")
         ;;
+	clean_raw_fgcz)
+		type="fgcz"
+		base=${clusterdir_old}/${bfabric_downloads}
+		#NOTE: projlist MUST be a bash array defined in fgcz.conf
+		if declare -p projlist &>/dev/null && \
+			declare -p projlist | grep -q 'declare \-a'; then
+			echo "projlist exists and is an array"
+		else
+			echo "projlist is not defined in fgcz.conf or not an array"
+		fi
+	;;
 	*)
 		echo "Error: unrecognized option"
 		exit 1
 	;;
 esac
 
-for subtype in ${virusbase[@]}; do
-	gawk -v d="${custom_date}" '$2 < d' \
-		"${clusterdir_old}/${subtype}/working/samples.tsv" > "${clusterdir_old}/${subtype}/working/samples.tsv.toclean"
-	while IFS=$'\t' read -r sample batch _rest; do
-		for item in "${togarbage[@]}"; do
-			tomove="${clusterdir_old}/${subtype}/${parent}/${sample}/${batch}/${item}"
-			subtype_garbagedir=${subtype#*/}
-			garbagedir="${clusterdir_old}/garbage/${virus}/${subtype_garbagedir}/${parent}/${sample}/${batch}/${item%/*}"
-			echo "Garbaging ${tomove}/"
-			if compgen -G "$tomove" > /dev/null; then
-				#eval tomove=$tomove
+if [[ "$type" == "fgcz" ]];then
+	for prj in "${projlist[@]}"; do
+		custom_date=$(date -d "6 months ago" +%Y/%m/%d)
+		garbagedir="${clusterdir_old}/garbage/${type}/${prj}"
+		readarray -t dirs < <(
+			ls -l "${base}/${prj}" --time-style=+'%Y/%m/%d %H:%M:%S' | \
+				awk -v d="$custom_date" '$6 < d { print $8 }' | \
+				tail -n +2
+		)
+		for d in "${dirs[@]}"; do
+			origin=${base}/${prj}/${d}
+  			echo "Processing directory: $origin"
+			shopt -s extglob
+			if [[ -f "${origin}/dataset.tsv" ]] || [[ -d "${origin}/DmxStats" ]]; then
 				if $doit; then
-					mkdir -p ${garbagedir}
-					eval "mv ${tomove} ${garbagedir}"
+					echo "mkdir -p ${garbagedir}/${d}"
+					eval "echo mv -- ${origin}/!(dataset.tsv|DmxStats) ${garbagedir}/${d}"
 				else
-					echo [dryrun] mkdir -p ${garbagedir}
-					eval "echo [dryrun] mv ${tomove} ${garbagedir}"
+					echo "[dryrun] mkdir -p ${garbagedir}/${d}"
+					eval "echo [dryrun] mv -- ${origin}/!(dataset.tsv|DmxStats) ${garbagedir}/${d}"
 				fi
+			else
+				if $doit; then
+                                        echo "mkdir -p ${garbagedir}"
+                                        eval "echo mv ${origin} ${garbagedir}"
+                                else
+                                        echo "[dryrun] mkdir -p ${garbagedir}"
+                                        eval "echo [dryrun] mv ${origin} ${garbagedir}"
+                                fi
 			fi
 		done
-	done < "${clusterdir_old}/${subtype}/working/samples.tsv.toclean"
-done
-
+	done
+else
+	for subtype in ${virusbase[@]}; do
+		gawk -v d="${custom_date}" '$2 < d' \
+			"${clusterdir_old}/${subtype}/working/samples.tsv" > "${clusterdir_old}/${subtype}/working/samples.tsv.toclean"
+		while IFS=$'\t' read -r sample batch _rest; do
+			for item in "${togarbage[@]}"; do
+				tomove="${clusterdir_old}/${subtype}/${parent}/${sample}/${batch}/${item}"
+				subtype_garbagedir=${subtype#*/}
+				garbagedir="${clusterdir_old}/garbage/${type}/${subtype_garbagedir}/${parent}/${sample}/${batch}/${item%/*}"
+				echo "Garbaging ${tomove}/"
+				if compgen -G "$tomove" > /dev/null; then
+					#eval tomove=$tomove
+					if $doit; then
+						mkdir -p ${garbagedir}
+						eval "mv ${tomove} ${garbagedir}"
+					else
+						echo [dryrun] mkdir -p ${garbagedir}
+						eval "echo [dryrun] mv ${tomove} ${garbagedir}"
+					fi
+				fi
+			done
+		done < "${clusterdir_old}/${subtype}/working/samples.tsv.toclean"
+	done
+fi


### PR DESCRIPTION
Added a command to delete the fgcz raw files in bfabric-downloads.
More specifically, the script does one of two things:
- if the delivery directory contains either the file dataset.tsv or the dir DmxStats, it garbages all files but the aforementioned two
- otherwise it garbages the entire directory

The reason for this is to keep around the metadata to help with debugging and development.

As before, the commands for the actual run are still encapsulated in echo to allow for quick testing and I will fully enable it before merging