### PR TITLE
Aviti correction

### DIFF
--- a/pangolin_src/batman.sh
+++ b/pangolin_src/batman.sh
@@ -108,8 +108,20 @@ case "$1" in
                 mv ${clusterdir_old}/${working}/samples_aviti.tsv ${clusterdir_old}/${working}/samples_aviti.tsv.old
                 touch ${clusterdir_old}/${working}/samples_aviti.tsv 
                 while IFS=$'\t' read -r col1 col2 col3 col4; do
-                        # 1) Check if length = 19 -> Aviti
-			if [ "${#col2}" -eq 19 ]; then
+                       #Check if the batches included are all Aviti
+                       # The projects.tsv files for a batch have a list of all delivery names that are included in the batch.
+                       # We get all delivery names, we loop over them. By default we say the batch has aviti. If any of the batches is not aviti, we set the flag to false.
+                       # Depending on the flag value we decide if the samples in the batch go into aviti or into pre-aviti
+                       prjtsv=${clusterdir_old}/${sampleset}/projects.${col2}.tsv
+                       deliverynames=$(awk '{print $4}' ${prjtsv} | sort -u)
+                       all_match=true
+                       while read -r val; do
+                               if echo $val | grep -qvi aviti; then
+                                       all_match=false
+                                       break
+                               fi
+                       done <<< "$deliverynames"
+                       if all_match; then
                                 batch_date=${col2%%_*}
                                 if [ "$batch_date" -gt $aviti_date ]; then
                                         echo -e "${col1}\t${col2}\t${col3}\t${col4}" >> ${clusterdir_old}/${working}/samples_aviti.tsv

--- a/pangolin_src/batman.sh
+++ b/pangolin_src/batman.sh
@@ -80,20 +80,21 @@ case "$1" in
                 ~/log/rotate
         ;;
         addsamples)
-                lst="${clusterdir_old}/${working}/samples.tsv"
+                lst="${clusterdir_old}/${working}/samples.recent.tsv"
 		avi_batches="${clusterdir_old}/${working}/avi_batches.tsv"
                 aviti=0
                 case "$2" in
                         --recent)
-                                lst="${clusterdir_old}/${working}/samples.recent.tsv"
                                 echo "syncing recent: ${lastmonth}, ${thismonth}"
                                 cat ${clusterdir_old}/${sampleset}/samples.{${lastmonth},${thismonth}}*.tsv | sort -u > "${clusterdir_old}/${working}/samples.recent.tsv"
                         ;;
                         --year)
-                                lst="${clusterdir_old}/${working}/samples.recent.tsv"
                                 echo "syncing year: ${year}"
                                 cat ${clusterdir_old}/${sampleset}/samples.${year}*.tsv | sort -u > "${clusterdir_old}/${working}/samples.recent.tsv"
                         ;;
+		        --all)
+				echo "syncing all"
+				cat ${clusterdir_old}/${sampleset}/samples.*.tsv | sort -u > "${clusterdir_old}/${working}/samples.recent.tsv"
                         *)
                                 echo "Unkown parameter ${2}" > /dev/stderr
                                 exit 2
@@ -113,6 +114,10 @@ case "$1" in
                        # We get all delivery names, we loop over them. By default we say the batch has aviti. If any of the batches is not aviti, we set the flag to false.
                        # Depending on the flag value we decide if the samples in the batch go into aviti or into pre-aviti
                        prjtsv=${clusterdir_old}/${sampleset}/projects.${col2}.tsv
+		       # If the projects file does not exist, skip the batch entirely
+		       if [[ ! -f ${prjtsv} ]]; then
+                               continue
+                       fi
                        deliverynames=$(awk '{print $4}' ${prjtsv} | sort -u)
                        all_match=true
                        while read -r val; do
@@ -121,13 +126,9 @@ case "$1" in
                                        break
                                fi
                        done <<< "$deliverynames"
-                       if all_match; then
-                                batch_date=${col2%%_*}
-                                if [ "$batch_date" -gt $aviti_date ]; then
-                                        echo -e "${col1}\t${col2}\t${col3}\t${col4}" >> ${clusterdir_old}/${working}/samples_aviti.tsv
-                                else
-                                        echo "skipping Aviti batch ${col2} as too old"
-                                fi
+                       if [[ $all_match == true ]]; then
+			        echo "${prjtsv} - Detected Aviti"
+                                echo -e "${col1}\t${col2}\t${col3}\t${col4}" >> ${clusterdir_old}/${working}/samples_aviti.tsv
 			# 2) Else check if batch name is listed in avi_batches file
         		elif grep -Fxq "${col2}" "$avi_batches"; then
             			echo -e "${col1}\t${col2}\t${col3}\t${col4}" >> ${clusterdir_old}/${working}/samples_aviti.tsv
@@ -135,7 +136,7 @@ case "$1" in
 			else
                                 echo -e "${col1}\t${col2}\t${col3}\t${col4}" >> ${clusterdir_old}/${working}/samples_pre-aviti.tsv
                         fi
-                done < ${clusterdir_old}/${working}/samples.tsv
+                done < ${clusterdir_old}/${working}/samples.recent.tsv
         ;;
         vpipe)
                 declare -A job


### PR DESCRIPTION
Batman.sh in addsamples function relies on the batch name length to decide if a batch is aviti or not. This breaks in case of merged batches.
Now batman.sh reads the projects.tsv file for the batch. In there we have a list of all samples, with the dellivery name for each in column 4.
We extract all unique values in column 4 and loop through them (this ensures that merged batches including multiple deliveries are evaluated fully), and we check if all unique delivery names contain the string "aviti" (case insensitive match). If yes, we add the samples to the samples_aviti.tsv file, otherwise to the samples_pre-aviti.tsv file.

@kirschen-k please do not merge the code yet. I do, however, appreciate a review.